### PR TITLE
Fix init command to create .env from template file

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -6,6 +6,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { addListeners, ISelect } from "./debug";
 import axios from "axios";
+import dotenv from "dotenv";
 
 const copyFiles = (source: string, destination: string) => {
   fs.readdirSync(source).forEach((file) => {
@@ -69,13 +70,6 @@ export const initCommand = async (type: "c" | "js", folderName: string) => {
   fs.mkdirSync(newProjectDir, { recursive: true });
 
   if (type === "c" || type === "js") {
-    // TODO: Remove this when jshooks is merged into mainnet
-    process.env.NETWORK_NAME = "testnet";
-    process.env.NETWORK_DOMAIN = "xahau-test.net";
-    if (type === "js") {
-      process.env.NETWORK_NAME = "jshooks";
-      process.env.NETWORK_DOMAIN = "jshooks.xahau-test.net";
-    }
     copyFiles(templateDir, newProjectDir);
     console.log(
       `Created ${
@@ -83,8 +77,16 @@ export const initCommand = async (type: "c" | "js", folderName: string) => {
       } project in ${newProjectDir}`
     );
     try {
+      const projectEnv = dotenv.config({
+        path: path.join(newProjectDir, ".env"),
+      });
+      if (!projectEnv.parsed) {
+        console.log("No .env file found in the project template.");
+        process.exit(1);
+      }
+      const env = projectEnv.parsed;
       const aliceResponse = await axios.post(
-        `https://${process.env.NETWORK_DOMAIN}/newcreds`
+        `https://${env.XRPLD_WSS.replace("wss://", "")}/newcreds`
       );
       if (aliceResponse.data.error) {
         console.error(aliceResponse.data.error);
@@ -95,9 +97,7 @@ export const initCommand = async (type: "c" | "js", folderName: string) => {
 
         const envFilePath = path.join(newProjectDir, ".env");
         const envObject = {
-          HOOKS_COMPILE_HOST: process.env.HOOKS_COMPILE_HOST || "",
-          XAHAU_ENV: process.env.NETWORK_NAME || "",
-          XRPLD_WSS: `wss://${process.env.NETWORK_DOMAIN}`,
+          ...env,
           ALICE_SEED: aliceSecret,
         };
         const envContent = Object.entries(envObject)

--- a/src/init/c/.env
+++ b/src/init/c/.env
@@ -1,5 +1,5 @@
 HOOKS_COMPILE_HOST=https://hook-buildbox.xrpl.org
-HOOKS_DEBUG_HOST=wss://jshooks.xahau-test.net/debugstream
+HOOKS_DEBUG_HOST=wss://xahau-test.net/debugstream
 XAHAU_ENV=testnet
-XRPLD_WSS=wss://jshooks.xahau-test.net
+XRPLD_WSS=wss://xahau-test.net
 ALICE_SEED=

--- a/test/integration/init.test.ts
+++ b/test/integration/init.test.ts
@@ -2,6 +2,7 @@ import { initCommand } from "../../src/commands";
 import * as fs from "fs";
 import * as path from "path";
 import axios from "axios";
+import { configDotenv } from "dotenv";
 
 jest.mock("axios");
 
@@ -33,6 +34,8 @@ describe("Init Tests", () => {
     const folderNameJS = "test-js-project";
     const projectPathC = path.join(process.cwd(), folderNameC);
     const projectPathJS = path.join(process.cwd(), folderNameJS);
+    const tempPathC = path.join(__dirname, "..", "..", "src", "init", "c");
+    const tempPathJS = path.join(__dirname, "..", "..", "src", "init", "js");
 
     beforeEach(() => {
       // Clean up any existing directories
@@ -76,9 +79,24 @@ describe("Init Tests", () => {
       // Verify contents of .env file
       const envContent = fs.readFileSync(envFilePath, "utf-8");
       expect(envContent).toContain("HOOKS_COMPILE_HOST");
+      expect(envContent).toContain("HOOKS_DEBUG_HOST");
       expect(envContent).toContain("XAHAU_ENV");
       expect(envContent).toContain("XRPLD_WSS");
       expect(envContent).toContain("ALICE_SEED=ss8Smfd73swruz4LATV5xkmydjZd6");
+
+      const env = configDotenv({ path: envFilePath }).parsed;
+      const originalEnv = configDotenv({
+        path: path.join(tempPathC, ".env"),
+      }).parsed;
+      expect(env?.HOOKS_COMPILE_HOST).toBeDefined();
+      expect(env?.HOOKS_COMPILE_HOST).toEqual(originalEnv?.HOOKS_COMPILE_HOST);
+      expect(env?.HOOKS_DEBUG_HOST).toBeDefined();
+      expect(env?.HOOKS_DEBUG_HOST).toEqual(originalEnv?.HOOKS_DEBUG_HOST);
+      expect(env?.XAHAU_ENV).toBeDefined();
+      expect(env?.XAHAU_ENV).toEqual(originalEnv?.XAHAU_ENV);
+      expect(env?.XRPLD_WSS).toBeDefined();
+      expect(env?.XRPLD_WSS).toEqual(originalEnv?.XRPLD_WSS);
+      expect(env?.ALICE_SEED).toBeDefined();
     });
 
     it("should initialize a new JS project", async () => {
@@ -102,9 +120,24 @@ describe("Init Tests", () => {
       // Verify contents of .env file
       const envContent = fs.readFileSync(envFilePath, "utf-8");
       expect(envContent).toContain("HOOKS_COMPILE_HOST");
+      expect(envContent).toContain("HOOKS_DEBUG_HOST");
       expect(envContent).toContain("XAHAU_ENV");
       expect(envContent).toContain("XRPLD_WSS");
       expect(envContent).toContain("ALICE_SEED=ss8Smfd73swruz4LATV5xkmydjZd6");
+
+      const env = configDotenv({ path: envFilePath }).parsed;
+      const originalEnv = configDotenv({
+        path: path.join(tempPathJS, ".env"),
+      }).parsed;
+      expect(env?.HOOKS_COMPILE_HOST).toBeDefined();
+      expect(env?.HOOKS_COMPILE_HOST).toEqual(originalEnv?.HOOKS_COMPILE_HOST);
+      expect(env?.HOOKS_DEBUG_HOST).toBeDefined();
+      expect(env?.HOOKS_DEBUG_HOST).toEqual(originalEnv?.HOOKS_DEBUG_HOST);
+      expect(env?.XAHAU_ENV).toBeDefined();
+      expect(env?.XAHAU_ENV).toEqual(originalEnv?.XAHAU_ENV);
+      expect(env?.XRPLD_WSS).toBeDefined();
+      expect(env?.XRPLD_WSS).toEqual(originalEnv?.XRPLD_WSS);
+      expect(env?.ALICE_SEED).toBeDefined();
     });
 
     it("should handle existing directory error", async () => {


### PR DESCRIPTION
## High Level Overview of Change

Fixed an issue where the value of HOOKS_COMPILE_HOST was not set in the .env file generated by the init command, or HOOKS_DEBUG_HOST was not set.

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->