### PR TITLE
Fix unreliable integration test directory cleanup

### DIFF
--- a/test/integration/build.test.ts
+++ b/test/integration/build.test.ts
@@ -37,14 +37,14 @@ describe("Build Tests", () => {
     beforeEach(() => {
       // Ensure output directory does not exist
       if (fs.existsSync(outDir)) {
-        fs.rmdirSync(outDir, { recursive: true });
+        fs.rmSync(outDir, { recursive: true, force: true });
       }
     });
 
     afterEach(() => {
       // Clean up
       if (fs.existsSync(outDir)) {
-        fs.rmdirSync(outDir, { recursive: true });
+        fs.rmSync(outDir, { recursive: true, force: true });
       }
     });
 
@@ -122,14 +122,14 @@ describe("Build Tests", () => {
     beforeEach(() => {
       // Ensure output directory does not exist
       if (fs.existsSync(outDir)) {
-        fs.rmdirSync(outDir, { recursive: true });
+        fs.rmSync(outDir, { recursive: true, force: true });
       }
     });
 
     afterEach(() => {
       // Clean up
       if (fs.existsSync(outDir)) {
-        fs.rmdirSync(outDir, { recursive: true });
+        fs.rmSync(outDir, { recursive: true, force: true });
       }
     });
 

--- a/test/integration/init.test.ts
+++ b/test/integration/init.test.ts
@@ -37,20 +37,20 @@ describe("Init Tests", () => {
     beforeEach(() => {
       // Clean up any existing directories
       if (fs.existsSync(projectPathC)) {
-        fs.rmdirSync(projectPathC, { recursive: true });
+        fs.rmSync(projectPathC, { recursive: true, force: true });
       }
       if (fs.existsSync(projectPathJS)) {
-        fs.rmdirSync(projectPathJS, { recursive: true });
+        fs.rmSync(projectPathJS, { recursive: true, force: true });
       }
     });
 
     afterEach(() => {
       // Clean up created directories
       if (fs.existsSync(projectPathC)) {
-        fs.rmdirSync(projectPathC, { recursive: true });
+        fs.rmSync(projectPathC, { recursive: true, force: true });
       }
       if (fs.existsSync(projectPathJS)) {
-        fs.rmdirSync(projectPathJS, { recursive: true });
+        fs.rmSync(projectPathJS, { recursive: true, force: true });
       }
     });
 


### PR DESCRIPTION
## High Level Overview of Change

Test setup/teardown used fs.rmdirSync, which fails when the target directory is not empty or no longer exists. That left stale artifacts between runs and made cleanup brittle.
Use fs.rmSync with recursive and force so directories are removed reliably regardless of contents.


### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->